### PR TITLE
Include percentage of year passed in title

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -16,7 +16,6 @@ meses = {
     9: "setembro", 10: "outubro", 11: "novembro", 12: "dezembro"
 }
 
-# Calculate the percentage of the year that has passed
 start_of_year = datetime.datetime(today.year, 1, 1, tzinfo=pytz.timezone('America/Sao_Paulo'))
 days_passed = (today - start_of_year).days + 1
 total_days_in_year = 366 if today.year % 4 == 0 and (today.year % 100 != 0 or today.year % 400 == 0) else 365

--- a/bot.py
+++ b/bot.py
@@ -16,7 +16,13 @@ meses = {
     9: "setembro", 10: "outubro", 11: "novembro", 12: "dezembro"
 }
 
-formatted_name = f"{today.day} de {meses[today.month]} de {today.year}"
+# Calculate the percentage of the year that has passed
+start_of_year = datetime.datetime(today.year, 1, 1, tzinfo=pytz.timezone('America/Sao_Paulo'))
+days_passed = (today - start_of_year).days + 1
+total_days_in_year = 366 if today.year % 4 == 0 and (today.year % 100 != 0 or today.year % 400 == 0) else 365
+percentage_of_year_passed = round((days_passed / total_days_in_year) * 100)
+
+formatted_name = f"{today.day} de {meses[today.month]} de {today.year} - {percentage_of_year_passed}% do ano"
 
 url = f"https://api.telegram.org/bot{TOKEN}/setChatTitle"
 dados = {"chat_id": CHAT_ID, "title": formatted_name}


### PR DESCRIPTION
Add the percentage of the year that has passed to the title in `bot.py`.

* Calculate the percentage of the year that has passed.
* Include the percentage in the `formatted_name` variable.
* Update the title format to include the percentage of the year that has passed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mspavanelli/TelegramChronos/pull/3?shareId=09f561c7-a812-491f-b300-dd0b170b451c).